### PR TITLE
Async refresh token

### DIFF
--- a/custom_components/miele/__init__.py
+++ b/custom_components/miele/__init__.py
@@ -111,7 +111,6 @@ async def async_setup(hass, config):
             config[DOMAIN].get(CONF_CLIENT_ID), config[DOMAIN].get(CONF_CLIENT_SECRET), 
             redirect_uri=callback_url,
             cache_path=cache)
-        await hass.data[DOMAIN][DATA_OAUTH].async_init()
 
     if not hass.data[DOMAIN][DATA_OAUTH].authorized:
         _LOGGER.info('no token; requesting authorization')

--- a/custom_components/miele/__init__.py
+++ b/custom_components/miele/__init__.py
@@ -111,6 +111,7 @@ async def async_setup(hass, config):
             config[DOMAIN].get(CONF_CLIENT_ID), config[DOMAIN].get(CONF_CLIENT_SECRET), 
             redirect_uri=callback_url,
             cache_path=cache)
+        await hass.data[DOMAIN][DATA_OAUTH].async_init()
 
     if not hass.data[DOMAIN][DATA_OAUTH].authorized:
         _LOGGER.info('no token; requesting authorization')

--- a/custom_components/miele/miele_at_home.py
+++ b/custom_components/miele/miele_at_home.py
@@ -102,8 +102,9 @@ class MieleOAuth(object):
             token=self._token,
             token_updater=self._save_token)
 
+    async def async_init(self):
         if self.authorized:
-            self.refresh_token()
+            await self.refresh_token()
 
     @property
     def authorized(self):

--- a/custom_components/miele/miele_at_home.py
+++ b/custom_components/miele/miele_at_home.py
@@ -102,9 +102,8 @@ class MieleOAuth(object):
             token=self._token,
             token_updater=self._save_token)
 
-    async def async_init(self):
         if self.authorized:
-            await self.refresh_token()
+            self.refresh_token()
 
     @property
     def authorized(self):
@@ -125,9 +124,9 @@ class MieleOAuth(object):
 
         return token
 
-    async def refresh_token(self):
+    def refresh_token(self):
         body = 'client_id={}&client_secret={}&'.format(self._client_id, self._client_secret)
-        self._token = await self._session.refresh_token(MieleOAuth.OAUTH_TOKEN_URL,
+        self._token = self._session.refresh_token(MieleOAuth.OAUTH_TOKEN_URL,
             body=body,
             refresh_token=self._token['refresh_token'])
         self._save_token(self._token)


### PR DESCRIPTION
This fixes #6. Notably, it fixes it by marking refresh_token as not async, as the session object's refresh_token also isn't async, and so results in HA whinging about "Detecting I/O inside the event loop". This could be fixed by replacing requests with HTTPX and using something like https://docs.authlib.org/en/stable/client/httpx.html